### PR TITLE
fix: remove premium member check for when

### DIFF
--- a/niconico/video/watch.py
+++ b/niconico/video/watch.py
@@ -348,10 +348,7 @@ class VideoWatchClient(BaseClient):
             "additionals": {},
         }
         if when is not None:
-            if self.niconico.premium:
-                payload["additionals"] = {"when": when}
-            else:
-                raise NicoAPIError(message="You must be a premium member to get the comments at a specific time.")
+            payload["additionals"] = {"when": when}
         if thread_key is not None:
             payload["threadKey"] = thread_key
         res = self.niconico.post(


### PR DESCRIPTION
The code runs fine even if user is not a premium member.

You can confirm by running `example/get_all_comments.py` as a normal account.