### PR TITLE
Add Like API integration

### DIFF
--- a/niconico/objects/nvapi.py
+++ b/niconico/objects/nvapi.py
@@ -285,3 +285,31 @@ class LikeData(BaseModel):
     """
 
     thanks_message: str | None = Field(None, alias="thanksMessage")
+
+
+class LikeHistoryItem(BaseModel):
+    """A class that represents a like history item."""
+
+    liked_at: str = Field(..., alias="likedAt")
+    thanks_message: str | None = Field(None, alias="thanksMessage")
+    video: EssentialVideo
+    status: str
+
+
+class LikeHistorySummary(BaseModel):
+    """A class that represents the summary of like history."""
+
+    has_next: bool = Field(..., alias="hasNext")
+    can_get_next_page: bool = Field(..., alias="canGetNextPage")
+    get_next_page_ng_reason: str | None = Field(None, alias="getNextPageNgReason")
+
+
+class LikeHistoryData(BaseModel):
+    """A class that represents the data of a like history response from the NvAPI.
+
+    ref: https://nvapi.nicovideo.jp/v1/users/me/likes
+    """
+
+    items: list[LikeHistoryItem]
+    summary: LikeHistorySummary
+

--- a/niconico/objects/nvapi.py
+++ b/niconico/objects/nvapi.py
@@ -276,3 +276,12 @@ class ThreadKeyData(BaseModel):
     """
 
     thread_key: str = Field(..., alias="threadKey")
+
+
+class LikeData(BaseModel):
+    """A class that represents the data of a like response from the NvAPI.
+
+    ref: https://nvapi.nicovideo.jp/v1/users/me/likes/items?videoId=<video_id>
+    """
+
+    thanks_message: str | None = Field(None, alias="thanksMessage")

--- a/niconico/video/__init__.py
+++ b/niconico/video/__init__.py
@@ -8,7 +8,7 @@ import requests
 
 from niconico.base.client import BaseClient
 from niconico.decorators import login_required
-from niconico.objects.nvapi import HistoryData, MylistData, NvAPIResponse, SeriesData, TagsData, VideosData
+from niconico.objects.nvapi import HistoryData, LikeData, MylistData, NvAPIResponse, SeriesData, TagsData, VideosData
 from niconico.video.ranking import VideoRankingClient
 from niconico.video.search import VideoSearchClient
 from niconico.video.watch import VideoWatchClient
@@ -134,6 +134,23 @@ class VideoClient(BaseClient):
         res = self.niconico.get(f"https://nvapi.nicovideo.jp/v1/users/me/watch/history?{query_str}")
         if res.status_code == requests.codes.ok:
             res_cls = NvAPIResponse[HistoryData](**res.json())
+            if res_cls.data is not None:
+                return res_cls.data
+        return None
+
+    @login_required()
+    def like_video(self, video_id: str) -> LikeData | None:
+        """Like a video.
+
+        Args:
+            video_id (str): The ID of the video to like.
+
+        Returns:
+            LikeData | None: The like data if successful, None otherwise.
+        """
+        res = self.niconico.post(f"https://nvapi.nicovideo.jp/v1/users/me/likes/items?videoId={video_id}")
+        if res.status_code == requests.codes.ok:
+            res_cls = NvAPIResponse[LikeData](**res.json())
             if res_cls.data is not None:
                 return res_cls.data
         return None

--- a/niconico/video/__init__.py
+++ b/niconico/video/__init__.py
@@ -8,7 +8,16 @@ import requests
 
 from niconico.base.client import BaseClient
 from niconico.decorators import login_required
-from niconico.objects.nvapi import HistoryData, LikeData, MylistData, NvAPIResponse, SeriesData, TagsData, VideosData
+from niconico.objects.nvapi import (
+    HistoryData,
+    LikeData,
+    LikeHistoryData,
+    MylistData,
+    NvAPIResponse,
+    SeriesData,
+    TagsData,
+    VideosData,
+)
 from niconico.video.ranking import VideoRankingClient
 from niconico.video.search import VideoSearchClient
 from niconico.video.watch import VideoWatchClient
@@ -151,6 +160,26 @@ class VideoClient(BaseClient):
         res = self.niconico.post(f"https://nvapi.nicovideo.jp/v1/users/me/likes/items?videoId={video_id}")
         if res.status_code == requests.codes.ok:
             res_cls = NvAPIResponse[LikeData](**res.json())
+            if res_cls.data is not None:
+                return res_cls.data
+        return None
+
+    @login_required()
+    def get_like_history(self, *, page_size: int = 25, page: int = 1) -> LikeHistoryData | None:
+        """Get the like history of the authenticated user.
+
+        Args:
+            page_size (int): The number of liked videos to get per page.
+            page (int): The page number.
+
+        Returns:
+            LikeHistoryData | None: The like history data if successful, None otherwise.
+        """
+        query = {"pageSize": str(page_size), "page": str(page)}
+        query_str = "&".join([f"{key}={value}" for key, value in query.items()])
+        res = self.niconico.get(f"https://nvapi.nicovideo.jp/v1/users/me/likes?{query_str}")
+        if res.status_code == requests.codes.ok:
+            res_cls = NvAPIResponse[LikeHistoryData](**res.json())
             if res_cls.data is not None:
                 return res_cls.data
         return None


### PR DESCRIPTION
We will submit pull requests for each feature that has been implemented for [MusicAssistant's niconico provider](https://github.com/Shi-553/server).

This pull request adds support for liking videos and retrieving like history in the NicoNico client. The main changes include new data models for like responses and history, updates to imports, and two new client methods for liking a video and fetching the user's like history.

### New features

* Added new data models: `LikeData`, `LikeHistoryItem`, `LikeHistorySummary`, and `LikeHistoryData` to represent like responses and history from the NvAPI.
* Introduced the `like_video` method to the client, allowing authenticated users to like a video and receive like response data.
* Added the `get_like_history` method to retrieve the authenticated user's like history, supporting pagination.
