### PR TITLE
Release v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@ It allows you to download videos, retrieve information, get comments, and more.
 
 ## Requirement
 
-| niconico.py version | Python version |
-| --- | --- |
-| 2.2.x | 3.11 or later |
-| 2.1.x | 3.8 or later |
+Python 3.11 or later is required.
 
 To use the video download function, you need to install [FFmpeg](https://www.ffmpeg.org/) and set the path.
 

--- a/niconico/__init__.py
+++ b/niconico/__init__.py
@@ -3,4 +3,4 @@
 from niconico.niconico import NicoNico
 
 __all__ = ("NicoNico",)
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "niconico.py"
-version = "2.1.0"
+version = "2.2.0"
 description = "API wrapper for NicoNico services"
 authors = [{ name = "Negima1072", email = "ngm1072@gmail.com" }]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "niconico-py"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "idna" },


### PR DESCRIPTION
## Summary
- Bump package and CLI version to 2.2.0.
- Update uv.lock for the release version.
- Simplify README requirements by removing the niconico.py version matrix and the 2.1.x row.

## Verification
- uv run --python 3.11 pytest
- uv run --python 3.11 ruff check .
- uv run --python 3.11 pyright
- uv build --python 3.11
- uv run --python 3.11 python -m niconico --version

## Release note
- After this PR is merged, tag v2.2.0 on the PR merge commit.
