### PR TITLE
docs: localize README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,7 @@
 ![niconico](https://img.shields.io/badge/niconico-(to%20i)-auto?logo=niconico&logoColor=%23e6e6e6&color=%23252525)
 
 [![PyPI](https://img.shields.io/pypi/v/niconico.py?logo=pypi)](https://pypi.org/project/niconico.py/)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-252525?logo=githubpages&logoColor=white)](https://niconicolibs.github.io/niconico.py/)
 ![Python](https://img.shields.io/badge/python-%3E%3D3.11-blue?logo=python&logoColor=white)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/niconico.py?logo=pypi)
 ![PyPI - License](https://img.shields.io/pypi/l/niconico.py?logo=pypi)

--- a/README.en.md
+++ b/README.en.md
@@ -12,22 +12,22 @@
 
 # <img src="https://avatars.githubusercontent.com/u/113749892" height="30" /> niconico.py
 
-niconico.py は、ニコニコ動画のコンテンツや情報を取得するための Python ライブラリです。
-動画のダウンロード、動画情報の取得、コメント取得などを扱えます。
+niconico.py is a Python library for retrieving Niconico video content and information.
+It supports video downloads, metadata retrieval, comment retrieval, and more.
 
-## 要件
+## Requirement
 
-Python 3.11 以降が必要です。
+Python 3.11 or later is required.
 
-動画ダウンロード機能を利用する場合は、[FFmpeg](https://www.ffmpeg.org/) をインストールしてパスを通してください。
+To use the video download function, install [FFmpeg](https://www.ffmpeg.org/) and make it available on your PATH.
 
-## インストール
+## Installation
 
 ```bash
 pip install niconico.py
 ```
 
-## 使い方
+## Usage
 
 ```python
 from niconico import NicoNico
@@ -35,22 +35,22 @@ from niconico import NicoNico
 client = NicoNico()
 ```
 
-### サンプル
+### Examples
 
-サンプルコードは [examples](https://github.com/niconicolibs/niconico.py/tree/main/examples) にあります。
+Example code is available in [examples](https://github.com/niconicolibs/niconico.py/tree/main/examples).
 
-## コマンド
+## Command
 
-CLI の使い方は次のコマンドで確認できます。
+Use the following command to see CLI usage.
 
 ```bash
 niconico -h
 ```
 
-## コントリビュート
+## Contributing
 
-コントリビューションは歓迎します。Issue や PR では、目的と変更内容が分かるように記載してください。
+Contributions are welcome. Please describe the purpose and scope clearly in issues and pull requests.
 
-## ライセンス
+## License
 
 [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![niconico](https://img.shields.io/badge/niconico-(to%20i)-auto?logo=niconico&logoColor=%23e6e6e6&color=%23252525)
 
 [![PyPI](https://img.shields.io/pypi/v/niconico.py?logo=pypi)](https://pypi.org/project/niconico.py/)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-252525?logo=githubpages&logoColor=white)](https://niconicolibs.github.io/niconico.py/)
 ![Python](https://img.shields.io/badge/python-%3E%3D3.11-blue?logo=python&logoColor=white)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/niconico.py?logo=pypi)
 ![PyPI - License](https://img.shields.io/pypi/l/niconico.py?logo=pypi)

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@
 niconico.py は、ニコニコ動画のコンテンツや情報を取得するための Python ライブラリです。
 動画のダウンロード、動画情報の取得、コメント取得などを扱えます。
 
-## 要件
+## Requirements
 
 Python 3.11 以降が必要です。
 
 動画ダウンロード機能を利用する場合は、[FFmpeg](https://www.ffmpeg.org/) をインストールしてパスを通してください。
 
-## インストール
+## Installation
 
 ```bash
 pip install niconico.py
 ```
 
-## 使い方
+## Usage
 
 ```python
 from niconico import NicoNico
@@ -35,11 +35,11 @@ from niconico import NicoNico
 client = NicoNico()
 ```
 
-### サンプル
+### Examples
 
 サンプルコードは [examples](https://github.com/niconicolibs/niconico.py/tree/main/examples) にあります。
 
-## コマンド
+## CLI
 
 CLI の使い方は次のコマンドで確認できます。
 
@@ -47,10 +47,10 @@ CLI の使い方は次のコマンドで確認できます。
 niconico -h
 ```
 
-## コントリビュート
+## Contributing
 
 コントリビューションは歓迎します。Issue や PR では、目的と変更内容が分かるように記載してください。
 
-## ライセンス
+## License
 
 [MIT License](LICENSE)


### PR DESCRIPTION
## Summary
- Make `README.md` Japanese by default.
- Add `README.en.md` as the English README.
- Add language switch links between the Japanese and English READMEs.
- Update the niconico badge text to `(to i)`.

## Verification
- `uv build --python 3.11`
