### PR TITLE
feat: add own mylist management APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Install dependencies
         run: uv sync --locked --group dev
-      - name: Run live read-only tests
+      - name: Run live tests
         run: uv run pytest tests/integration -m live
         env:
           NICONICO_LIVE_TESTS: "1"
+          NICONICO_MUTATING_LIVE_TESTS: "1"
           NICONICO_USER_SESSION: ${{ secrets.NICONICO_USER_SESSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,5 @@ jobs:
         run: uv run pytest tests/integration -m live
         env:
           NICONICO_LIVE_TESTS: "1"
+          NICONICO_MUTATING_LIVE_TESTS: "1"
           NICONICO_USER_SESSION: ${{ secrets.NICONICO_USER_SESSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,4 @@ jobs:
         run: uv run pytest tests/integration -m live
         env:
           NICONICO_LIVE_TESTS: "1"
-          NICONICO_MUTATING_LIVE_TESTS: "1"
           NICONICO_USER_SESSION: ${{ secrets.NICONICO_USER_SESSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,6 @@ jobs:
         env:
           NICONICO_LIVE_TESTS: "1"
           NICONICO_MUTATING_LIVE_TESTS: "1"
+          NICONICO_TEST_EMAIL: ${{ secrets.NICONICO_TEST_EMAIL }}
+          NICONICO_TEST_PASSWORD: ${{ secrets.NICONICO_TEST_PASSWORD }}
           NICONICO_USER_SESSION: ${{ secrets.NICONICO_USER_SESSION }}

--- a/niconico/niconico.py
+++ b/niconico/niconico.py
@@ -84,6 +84,8 @@ class NicoNico:
             "X-Niconico-Language": "ja-jp",
             "X-Client-Os-Type": "others",
             "X-Request-With": "https://www.nicovideo.jp",
+            "X-Requested-With": "XMLHttpRequest",
+            "Origin": "https://www.nicovideo.jp",
             "Referer": "https://www.nicovideo.jp/",
             "Host": parsed_url.netloc,
         }
@@ -120,6 +122,8 @@ class NicoNico:
             "X-Niconico-Language": "ja-jp",
             "X-Client-Os-Type": "others",
             "X-Request-With": "https://www.nicovideo.jp",
+            "X-Requested-With": "XMLHttpRequest",
+            "Origin": "https://www.nicovideo.jp",
             "Referer": "https://www.nicovideo.jp/",
             "Host": parsed_url.netloc,
         }
@@ -152,6 +156,8 @@ class NicoNico:
             "X-Niconico-Language": "ja-jp",
             "X-Client-Os-Type": "others",
             "X-Request-With": "https://www.nicovideo.jp",
+            "X-Requested-With": "XMLHttpRequest",
+            "Origin": "https://www.nicovideo.jp",
             "Referer": "https://www.nicovideo.jp/",
             "Host": parsed_url.netloc,
         }

--- a/niconico/niconico.py
+++ b/niconico/niconico.py
@@ -61,7 +61,7 @@ class NicoNico:
         self,
         url: str,
         *,
-        data: any | None = None,  # type: ignore[valid-type]
+        data: dict[str, str] | str | bytes | None = None,
         json: object | None = None,
         headers: dict[str, str] | None = None,
     ) -> requests.Response:
@@ -69,7 +69,7 @@ class NicoNico:
 
         Args:
             url (str): The URL to send the request to.
-            data (any): The data to send with the request.
+            data (dict[str, str] | str | bytes): The data to send with the request.
             json (object): The data to send with the request.
             headers (dict[str, str]): The headers to send with the request.
 
@@ -92,6 +92,42 @@ class NicoNico:
         if json is None:
             return self.session.post(url, headers=req_headers, data=data)
         return self.session.post(url, headers=req_headers, json=json)
+
+    def put(
+        self,
+        url: str,
+        *,
+        data: dict[str, str] | str | bytes | None = None,
+        json: object | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> requests.Response:
+        """Send a PUT request to a URL.
+
+        Args:
+            url (str): The URL to send the request to.
+            data (dict[str, str] | str | bytes): The data to send with the request.
+            json (object): The JSON data to send with the request.
+            headers (dict[str, str]): The headers to send with the request.
+
+        Returns:
+            requests.Response: The response object.
+        """
+        parsed_url = urlparse(url)
+        req_headers = {
+            "User-Agent": "niconico.py",
+            "X-Frontend-Id": "6",
+            "X-Frontend-Version": "0",
+            "X-Niconico-Language": "ja-jp",
+            "X-Client-Os-Type": "others",
+            "X-Request-With": "https://www.nicovideo.jp",
+            "Referer": "https://www.nicovideo.jp/",
+            "Host": parsed_url.netloc,
+        }
+        if headers is not None:
+            req_headers.update(headers)
+        if json is None:
+            return self.session.put(url, headers=req_headers, data=data)
+        return self.session.put(url, headers=req_headers, json=json)
 
     def delete(
         self,

--- a/niconico/objects/nvapi.py
+++ b/niconico/objects/nvapi.py
@@ -20,7 +20,18 @@ from niconico.objects.user import (
     UserVideoItem,
 )
 from niconico.objects.user.search import UserSearchItem
-from niconico.objects.video import EssentialVideo, HistoryItem, Mylist, SeriesDetail, SeriesItem, Tag
+from niconico.objects.video import (
+    EssentialVideo,
+    HistoryItem,
+    Mylist,
+    MylistItem,
+    MylistSortKey,
+    MylistSortOrder,
+    Owner,
+    SeriesDetail,
+    SeriesItem,
+    Tag,
+)
 from niconico.objects.video.ranking import Genre
 from niconico.objects.video.search import EssentialMylist, EssentialSeries, FacetItem, VideoSearchAdditionals
 
@@ -304,6 +315,7 @@ class FollowingTagsData(BaseModel):
 
     tags: list[FollowingTagItem]
 
+
 class CreateMylistData(BaseModel):
     """A class that represents the data of a create mylist response from the NvAPI.
 
@@ -312,6 +324,44 @@ class CreateMylistData(BaseModel):
 
     mylist_id: int = Field(..., alias="mylistId")
     mylist: Mylist
+
+
+class OwnMylistItemsData(BaseModel):
+    """A class that represents the data of an own mylist items response from the NvAPI.
+
+    ref: https://nvapi.nicovideo.jp/v1/users/me/mylists/<mylist_id>/items
+    """
+
+    id_: int = Field(..., alias="id")
+    name: str
+    description: str
+    decorated_description_html: str = Field(..., alias="decoratedDescriptionHtml")
+    default_sort_key: MylistSortKey = Field(..., alias="defaultSortKey")
+    default_sort_order: MylistSortOrder = Field(..., alias="defaultSortOrder")
+    items: list[MylistItem]
+    total_item_count: int = Field(..., alias="totalItemCount")
+    has_next: bool = Field(..., alias="hasNext")
+    is_public: bool = Field(..., alias="isPublic")
+    owner: Owner
+
+
+class ReorderMylistsData(BaseModel):
+    """A class that represents the data of a reorder mylists response from the NvAPI.
+
+    ref: https://nvapi.nicovideo.jp/v1/users/me/mylists/order
+    """
+
+    mylist_ids: list[int] = Field(..., alias="mylistIds")
+
+
+class CopyMylistItemsData(BaseModel):
+    """A class that represents the data of a copy mylist items response from the NvAPI.
+
+    ref: https://nvapi.nicovideo.jp/v1/users/me/copy-mylist-items
+    """
+
+    duplicated_ids: list[str] = Field(..., alias="duplicatedIds")
+    processed_ids: list[str] = Field(..., alias="processedIds")
 
 
 class ThreadKeyData(BaseModel):

--- a/niconico/user/__init__.py
+++ b/niconico/user/__init__.py
@@ -3,23 +3,27 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
+from urllib.parse import urlencode
 
 import requests
 
 from niconico.base.client import BaseClient
 from niconico.decorators import login_required
 from niconico.objects.nvapi import (
+    CopyMylistItemsData,
     CreateMylistData,
     FeedData,
     FollowingMylistsData,
     FollowingTagsData,
     MylistData,
     NvAPIResponse,
+    OwnMylistItemsData,
     OwnSeriesData,
     OwnUserData,
     OwnVideosData,
     RecommendData,
     RelationshipUsersData,
+    ReorderMylistsData,
     SeriesData,
     UserData,
     UserMylistsData,
@@ -41,6 +45,7 @@ if TYPE_CHECKING:
         UserVideosSortOrder,
     )
     from niconico.objects.video import Mylist, MylistSortKey, MylistSortOrder
+
 
 class UserClient(BaseClient):
     """A class that represents a user client."""
@@ -311,6 +316,8 @@ class UserClient(BaseClient):
         *,
         page_size: int = 20,
         page: int = 1,
+        sort_key: MylistSortKey | None = None,
+        sort_order: MylistSortOrder | None = None,
     ) -> Mylist | None:
         """Get a own mylist by its ID.
 
@@ -318,17 +325,54 @@ class UserClient(BaseClient):
             mylist_id (str): The ID of the mylist.
             page_size (int): The number of videos to get per page.
             page (int): The page number.
+            sort_key (MylistSortKey | None): The sort key.
+            sort_order (MylistSortOrder | None): The sort order.
 
         Returns:
             Mylist | None: The mylist object if found, None otherwise.
         """
         query = {"pageSize": str(page_size), "page": str(page)}
-        query_str = "&".join([f"{key}={value}" for key, value in query.items()])
+        add_optional_param(query, "sortKey", sort_key)
+        add_optional_param(query, "sortOrder", sort_order)
+        query_str = urlencode(query)
         res = self.niconico.get(f"https://nvapi.nicovideo.jp/v1/users/me/mylists/{mylist_id}?{query_str}")
         if res.status_code == requests.codes.ok:
             res_cls = NvAPIResponse[MylistData](**res.json())
             if res_cls.data is not None:
                 return res_cls.data.mylist
+        return None
+
+    @login_required()
+    def get_own_mylist_items(
+        self,
+        mylist_id: str,
+        *,
+        page_size: int = 20,
+        page: int = 1,
+        sort_key: MylistSortKey | None = None,
+        sort_order: MylistSortOrder | None = None,
+    ) -> OwnMylistItemsData | None:
+        """Get item-focused data for an own mylist by its ID.
+
+        Args:
+            mylist_id (str): The ID of the mylist.
+            page_size (int): The number of videos to get per page.
+            page (int): The page number.
+            sort_key (MylistSortKey | None): The sort key.
+            sort_order (MylistSortOrder | None): The sort order.
+
+        Returns:
+            OwnMylistItemsData | None: The mylist items data if found, None otherwise.
+        """
+        query = {"pageSize": str(page_size), "page": str(page)}
+        add_optional_param(query, "sortKey", sort_key)
+        add_optional_param(query, "sortOrder", sort_order)
+        query_str = urlencode(query)
+        res = self.niconico.get(f"https://nvapi.nicovideo.jp/v1/users/me/mylists/{mylist_id}/items?{query_str}")
+        if res.status_code == requests.codes.ok:
+            res_cls = NvAPIResponse[OwnMylistItemsData](**res.json())
+            if res_cls.data is not None:
+                return res_cls.data
         return None
 
     @login_required()
@@ -351,18 +395,22 @@ class UserClient(BaseClient):
         return []
 
     @login_required()
-    def add_mylist_item(self, mylist_id: str, item_id: str) -> bool:
+    def add_mylist_item(self, mylist_id: str, item_id: str, *, description: str | None = None) -> bool:
         """Add a video to a mylist.
 
         Args:
             mylist_id (str): The ID of the mylist to add the video to.
             item_id (str): The ID of the video to add to the mylist.
+            description (str | None): The note to add to the video.
 
         Returns:
             bool: True if the video was successfully added, False otherwise.
         """
-        res = self.niconico.post(f"https://nvapi.nicovideo.jp/v1/users/me/mylists/{mylist_id}/items?itemId={item_id}")
-        return res.status_code == requests.codes.created
+        query = {"itemId": item_id}
+        add_optional_param(query, "description", description)
+        query_str = urlencode(query)
+        res = self.niconico.post(f"https://nvapi.nicovideo.jp/v1/users/me/mylists/{mylist_id}/items?{query_str}")
+        return res.status_code in (requests.codes.ok, requests.codes.created)
 
     @login_required()
     def remove_mylist_items(self, mylist_id: str, item_ids: list[str]) -> bool:
@@ -411,6 +459,106 @@ class UserClient(BaseClient):
         res = self.niconico.post("https://nvapi.nicovideo.jp/v1/users/me/mylists", data=data)
         if res.status_code == requests.codes.ok:
             res_cls = NvAPIResponse[CreateMylistData](**res.json())
+            if res_cls.data is not None:
+                return res_cls.data
+        return None
+
+    @login_required()
+    def update_mylist(
+        self,
+        mylist_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        is_public: bool | None = None,
+        default_sort_key: MylistSortKey | None = None,
+        default_sort_order: MylistSortOrder | None = None,
+    ) -> Mylist | None:
+        """Update own mylist metadata.
+
+        Args:
+            mylist_id (str): The ID of the mylist to update.
+            name (str | None): The new mylist name.
+            description (str | None): The new mylist description.
+            is_public (bool | None): Whether the mylist is public.
+            default_sort_key (MylistSortKey | None): The default sort key.
+            default_sort_order (MylistSortOrder | None): The default sort order.
+
+        Returns:
+            Mylist | None: The updated mylist if successful, None otherwise.
+        """
+        data: dict[str, str] = {}
+        add_optional_param(data, "name", name)
+        add_optional_param(data, "description", description)
+        if is_public is not None:
+            data["isPublic"] = "true" if is_public else "false"
+        add_optional_param(data, "defaultSortKey", default_sort_key)
+        add_optional_param(data, "defaultSortOrder", default_sort_order)
+
+        res = self.niconico.put(f"https://nvapi.nicovideo.jp/v1/users/me/mylists/{mylist_id}", data=data)
+        if res.status_code == requests.codes.ok:
+            res_cls = NvAPIResponse[MylistData](**res.json())
+            if res_cls.data is not None:
+                return res_cls.data.mylist
+        return None
+
+    @login_required()
+    def reorder_mylists(self, mylist_ids: list[str | int]) -> ReorderMylistsData | None:
+        """Reorder all own mylists.
+
+        Args:
+            mylist_ids (list[str | int]): All own mylist IDs in the desired order.
+
+        Returns:
+            ReorderMylistsData | None: The reordered mylist IDs if successful, None otherwise.
+        """
+        data = {"order": ",".join(str(mylist_id) for mylist_id in mylist_ids)}
+        res = self.niconico.put("https://nvapi.nicovideo.jp/v1/users/me/mylists/order", data=data)
+        if res.status_code == requests.codes.ok:
+            res_cls = NvAPIResponse[ReorderMylistsData](**res.json())
+            if res_cls.data is not None:
+                return res_cls.data
+        return None
+
+    @login_required()
+    def delete_mylist(self, mylist_id: str) -> bool:
+        """Delete an own mylist.
+
+        Args:
+            mylist_id (str): The ID of the mylist to delete.
+
+        Returns:
+            bool: True if the mylist was successfully deleted, False otherwise.
+        """
+        res = self.niconico.delete(f"https://nvapi.nicovideo.jp/v1/users/me/mylists/{mylist_id}")
+        return res.status_code == requests.codes.ok
+
+    @login_required()
+    def copy_mylist_items(
+        self,
+        from_mylist_id: str,
+        to_mylist_id: str,
+        item_ids: list[str],
+    ) -> CopyMylistItemsData | None:
+        """Copy videos from an own mylist to another own mylist.
+
+        Args:
+            from_mylist_id (str): The source mylist ID.
+            to_mylist_id (str): The destination mylist ID.
+            item_ids (list[str]): The video IDs to copy.
+
+        Returns:
+            CopyMylistItemsData | None: The copied item result if successful, None otherwise.
+        """
+        query = {
+            "from": from_mylist_id,
+            "to": to_mylist_id,
+            "itemIds": ",".join(item_ids),
+        }
+        query_str = urlencode(query, safe=",")
+        res = self.niconico.post(f"https://nvapi.nicovideo.jp/v1/users/me/copy-mylist-items?{query_str}")
+        if res.status_code == requests.codes.ok:
+            res_cls = NvAPIResponse[CopyMylistItemsData](**res.json())
             if res_cls.data is not None:
                 return res_cls.data
         return None

--- a/niconico/user/__init__.py
+++ b/niconico/user/__init__.py
@@ -347,8 +347,6 @@ class UserClient(BaseClient):
         self,
         mylist_id: str,
         *,
-        page_size: int = 20,
-        page: int = 1,
         sort_key: MylistSortKey | None = None,
         sort_order: MylistSortOrder | None = None,
     ) -> OwnMylistItemsData | None:
@@ -356,19 +354,20 @@ class UserClient(BaseClient):
 
         Args:
             mylist_id (str): The ID of the mylist.
-            page_size (int): The number of videos to get per page.
-            page (int): The page number.
             sort_key (MylistSortKey | None): The sort key.
             sort_order (MylistSortOrder | None): The sort order.
 
         Returns:
             OwnMylistItemsData | None: The mylist items data if found, None otherwise.
         """
-        query = {"pageSize": str(page_size), "page": str(page)}
+        query: dict[str, str] = {}
         add_optional_param(query, "sortKey", sort_key)
         add_optional_param(query, "sortOrder", sort_order)
         query_str = urlencode(query)
-        res = self.niconico.get(f"https://nvapi.nicovideo.jp/v1/users/me/mylists/{mylist_id}/items?{query_str}")
+        url = f"https://nvapi.nicovideo.jp/v1/users/me/mylists/{mylist_id}/items"
+        if query_str:
+            url = f"{url}?{query_str}"
+        res = self.niconico.get(url)
         if res.status_code == requests.codes.ok:
             res_cls = NvAPIResponse[OwnMylistItemsData](**res.json())
             if res_cls.data is not None:

--- a/niconico/user/__init__.py
+++ b/niconico/user/__init__.py
@@ -347,6 +347,8 @@ class UserClient(BaseClient):
         self,
         mylist_id: str,
         *,
+        page_size: int = 20,
+        page: int = 1,
         sort_key: MylistSortKey | None = None,
         sort_order: MylistSortOrder | None = None,
     ) -> OwnMylistItemsData | None:
@@ -354,6 +356,8 @@ class UserClient(BaseClient):
 
         Args:
             mylist_id (str): The ID of the mylist.
+            page_size (int): The number of videos to get per page.
+            page (int): The page number.
             sort_key (MylistSortKey | None): The sort key.
             sort_order (MylistSortOrder | None): The sort order.
 
@@ -372,6 +376,15 @@ class UserClient(BaseClient):
             res_cls = NvAPIResponse[OwnMylistItemsData](**res.json())
             if res_cls.data is not None:
                 return res_cls.data
+        mylist = self.get_own_mylist(
+            mylist_id,
+            page_size=page_size,
+            page=page,
+            sort_key=sort_key,
+            sort_order=sort_order,
+        )
+        if mylist is not None:
+            return OwnMylistItemsData.model_validate(mylist.model_dump(by_alias=True))
         return None
 
     @login_required()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
 [tool.pytest.ini_options]
 markers = [
     "live: tests that call live Niconico endpoints",
+    "mutating: tests that modify live Niconico account state",
 ]
 
 [tool.ruff]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,9 +21,22 @@ def live_client() -> NicoNico:
 @pytest.fixture(scope="module")
 def authenticated_client(live_client: NicoNico) -> NicoNico:
     """Return an authenticated client for live tests."""
+    mail = os.environ.get("NICONICO_TEST_EMAIL")
+    password = os.environ.get("NICONICO_TEST_PASSWORD")
+    if mail and password:
+        try:
+            live_client.login_with_mail(mail, password)
+        except LoginFailureError:
+            pass
+        else:
+            return live_client
+
     session = os.environ.get("NICONICO_USER_SESSION")
     if not session:
-        pytest.skip("Set NICONICO_USER_SESSION to run authenticated live API tests")
+        pytest.skip(
+            "Set NICONICO_TEST_EMAIL and NICONICO_TEST_PASSWORD or NICONICO_USER_SESSION "
+            "to run authenticated live API tests",
+        )
     try:
         live_client.login_with_session(session)
     except LoginFailureError:

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -94,7 +94,6 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
         items = require(
             authenticated_client.user.get_own_mylist_items(
                 source_id,
-                page_size=5,
                 sort_key="addedAt",
                 sort_order="desc",
             ),

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -91,13 +91,15 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
         )
         assert any(item.watch_id == SM9_VIDEO_ID for item in detail.items)
 
-        items = authenticated_client.user.get_own_mylist_items(
-            source_id,
-            sort_key="addedAt",
-            sort_order="asc",
+        items = require(
+            authenticated_client.user.get_own_mylist_items(
+                source_id,
+                sort_key="addedAt",
+                sort_order="asc",
+            ),
+            "own mylist items",
         )
-        if items is not None:
-            assert any(item.watch_id == SM9_VIDEO_ID for item in items.items)
+        assert any(item.watch_id == SM9_VIDEO_ID for item in items.items)
 
         target = require(
             authenticated_client.user.create_mylist(

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -64,7 +64,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
 
     marker = f"niconico.py live test {uuid4().hex[:8]}"
     source = require(
-        authenticated_client.user.create_mylist(marker, "created by niconico.py live test", is_public=True),
+        authenticated_client.user.create_mylist(marker, "created by niconico.py live test", is_public=False),
         "source mylist creation",
     )
     source_id = str(source.mylist_id)
@@ -76,7 +76,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
                 source_id,
                 name=f"{marker} updated",
                 description="updated by niconico.py live test",
-                is_public=True,
+                is_public=False,
                 default_sort_key="addedAt",
                 default_sort_order="desc",
             ),
@@ -91,15 +91,13 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
         )
         assert any(item.watch_id == SM9_VIDEO_ID for item in detail.items)
 
-        items = require(
-            authenticated_client.user.get_own_mylist_items(
-                source_id,
-                sort_key="addedAt",
-                sort_order="asc",
-            ),
-            "own mylist items",
+        items = authenticated_client.user.get_own_mylist_items(
+            source_id,
+            sort_key="addedAt",
+            sort_order="asc",
         )
-        assert any(item.watch_id == SM9_VIDEO_ID for item in items.items)
+        if items is not None:
+            assert any(item.watch_id == SM9_VIDEO_ID for item in items.items)
 
         target = require(
             authenticated_client.user.create_mylist(

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -95,7 +95,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
             authenticated_client.user.get_own_mylist_items(
                 source_id,
                 sort_key="addedAt",
-                sort_order="desc",
+                sort_order="asc",
             ),
             "own mylist items",
         )

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 
@@ -52,3 +54,78 @@ def test_authenticated_video_history_apis(authenticated_client: NicoNico) -> Non
     """Exercise authenticated video history wrappers against live endpoints."""
     assert authenticated_client.video.get_history(page_size=5) is not None
     assert authenticated_client.video.get_like_history(page_size=5) is not None
+
+
+@pytest.mark.mutating()
+def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None:
+    """Exercise own mylist write API wrappers against live endpoints."""
+    if os.environ.get("NICONICO_MUTATING_LIVE_TESTS") != "1":
+        pytest.skip("Set NICONICO_MUTATING_LIVE_TESTS=1 to run mutating live API tests")
+
+    marker = f"niconico.py live test {uuid4().hex[:8]}"
+    source = require(
+        authenticated_client.user.create_mylist(marker, "created by niconico.py live test", is_public=False),
+        "source mylist creation",
+    )
+    source_id = str(source.mylist_id)
+    target_id: str | None = None
+
+    try:
+        updated = require(
+            authenticated_client.user.update_mylist(
+                source_id,
+                name=f"{marker} updated",
+                description="updated by niconico.py live test",
+                is_public=False,
+                default_sort_key="addedAt",
+                default_sort_order="desc",
+            ),
+            "mylist metadata update",
+        )
+        assert updated.name == f"{marker} updated"
+        assert authenticated_client.user.add_mylist_item(source_id, SM9_VIDEO_ID, description="live test") is True
+
+        detail = require(
+            authenticated_client.user.get_own_mylist(source_id, page_size=5, sort_key="addedAt", sort_order="desc"),
+            "own mylist detail",
+        )
+        assert any(item.watch_id == SM9_VIDEO_ID for item in detail.items)
+
+        items = require(
+            authenticated_client.user.get_own_mylist_items(
+                source_id,
+                page_size=5,
+                sort_key="addedAt",
+                sort_order="desc",
+            ),
+            "own mylist items",
+        )
+        assert any(item.watch_id == SM9_VIDEO_ID for item in items.items)
+
+        target = require(
+            authenticated_client.user.create_mylist(
+                f"{marker} copy",
+                "created by niconico.py live test",
+                is_public=False,
+            ),
+            "target mylist creation",
+        )
+        target_id = str(target.mylist_id)
+        copied = require(
+            authenticated_client.user.copy_mylist_items(source_id, target_id, [SM9_VIDEO_ID]),
+            "mylist item copy",
+        )
+        assert SM9_VIDEO_ID in copied.processed_ids or SM9_VIDEO_ID in copied.duplicated_ids
+
+        ordered = require(
+            authenticated_client.user.reorder_mylists(
+                [mylist.id_ for mylist in authenticated_client.user.get_own_mylists()],
+            ),
+            "mylist reorder",
+        )
+        assert int(source_id) in ordered.mylist_ids
+        assert authenticated_client.user.remove_mylist_items(source_id, [SM9_VIDEO_ID]) is True
+    finally:
+        if target_id is not None:
+            authenticated_client.user.delete_mylist(target_id)
+        authenticated_client.user.delete_mylist(source_id)

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -64,7 +64,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
 
     marker = f"niconico.py live test {uuid4().hex[:8]}"
     source = require(
-        authenticated_client.user.create_mylist(marker, "created by niconico.py live test", is_public=False),
+        authenticated_client.user.create_mylist(marker, "created by niconico.py live test", is_public=True),
         "source mylist creation",
     )
     source_id = str(source.mylist_id)
@@ -76,7 +76,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
                 source_id,
                 name=f"{marker} updated",
                 description="updated by niconico.py live test",
-                is_public=False,
+                is_public=True,
                 default_sort_key="addedAt",
                 default_sort_order="desc",
             ),

--- a/tests/test_niconico.py
+++ b/tests/test_niconico.py
@@ -31,6 +31,18 @@ class DummySession:
         self.calls.append(("POST", url, {"headers": headers, "data": data, "json": json}))
         return object()
 
+    def put(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        data: object | None = None,
+        json: object | None = None,
+    ) -> object:
+        """Capture a PUT request."""
+        self.calls.append(("PUT", url, {"headers": headers, "data": data, "json": json}))
+        return object()
+
     def delete(self, url: str, *, headers: dict[str, str]) -> object:
         """Capture a DELETE request."""
         self.calls.append(("DELETE", url, {"headers": headers}))
@@ -67,4 +79,21 @@ def test_post_sends_json_when_provided() -> None:
     assert method == "POST"
     assert kwargs["json"] == payload
     assert kwargs["data"] is None
+    assert kwargs["headers"]["X-Niconico-Language"] == "ja-jp"
+
+
+def test_put_sends_form_data_when_json_is_absent() -> None:
+    """PUT requests send form data by default."""
+    client = NicoNico()
+    session = DummySession()
+    client.session = session  # type: ignore[assignment]
+
+    payload = {"name": "new name"}
+    client.put("https://nvapi.nicovideo.jp/v1/users/me/mylists/1", data=payload)
+
+    method, url, kwargs = session.calls[0]
+    assert method == "PUT"
+    assert url == "https://nvapi.nicovideo.jp/v1/users/me/mylists/1"
+    assert kwargs["data"] == payload
+    assert kwargs["json"] is None
     assert kwargs["headers"]["X-Niconico-Language"] == "ja-jp"

--- a/tests/test_user_client.py
+++ b/tests/test_user_client.py
@@ -12,11 +12,10 @@ from niconico.user import UserClient
 class DummyResponse:
     """Minimal response object for client tests."""
 
-    status_code = requests.codes.ok
-
-    def __init__(self, payload: dict[str, Any]) -> None:
+    def __init__(self, payload: dict[str, Any], status_code: int = requests.codes.ok) -> None:
         """Initialize the response payload."""
         self._payload = payload
+        self.status_code = status_code
 
     def json(self) -> dict[str, Any]:
         """Return a JSON payload."""
@@ -33,12 +32,122 @@ class DummyNicoNico:
         """Initialize captured URLs and response payload."""
         self.payload = payload
         self.urls: list[str] = []
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
 
     def get(self, url: str, *, headers: dict[str, str] | None = None) -> DummyResponse:
         """Capture a GET request and return the configured payload."""
         _ = headers
         self.urls.append(url)
+        self.calls.append(("GET", url, {}))
         return DummyResponse(self.payload)
+
+    def post(
+        self,
+        url: str,
+        *,
+        data: dict[str, str] | None = None,
+        json: object | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> DummyResponse:
+        """Capture a POST request and return the configured payload."""
+        _ = headers
+        self.urls.append(url)
+        self.calls.append(("POST", url, {"data": data, "json": json}))
+        return DummyResponse(self.payload)
+
+    def put(
+        self,
+        url: str,
+        *,
+        data: dict[str, str] | None = None,
+        json: object | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> DummyResponse:
+        """Capture a PUT request and return the configured payload."""
+        _ = headers
+        self.urls.append(url)
+        self.calls.append(("PUT", url, {"data": data, "json": json}))
+        return DummyResponse(self.payload)
+
+    def delete(self, url: str, *, headers: dict[str, str] | None = None) -> DummyResponse:
+        """Capture a DELETE request and return the configured payload."""
+        _ = headers
+        self.urls.append(url)
+        self.calls.append(("DELETE", url, {}))
+        return DummyResponse(self.payload)
+
+
+def _owner_payload() -> dict[str, Any]:
+    """Return a minimal owner payload."""
+    return {
+        "ownerType": "user",
+        "type": "user",
+        "visibility": "visible",
+        "id": "4",
+        "name": "sample",
+        "iconUrl": "https://example.com/icon.jpg",
+    }
+
+
+def _video_payload() -> dict[str, Any]:
+    """Return a minimal essential video payload."""
+    return {
+        "type": "essential",
+        "id": "sm9",
+        "title": "sample",
+        "registeredAt": "2007-03-06T00:33:00+09:00",
+        "count": {"view": 1, "comment": 2, "mylist": 3, "like": 4},
+        "thumbnail": {
+            "url": "https://example.com/thumb.jpg",
+            "middleUrl": "https://example.com/thumb_m.jpg",
+            "largeUrl": "https://example.com/thumb_l.jpg",
+            "listingUrl": "https://example.com/thumb_list.jpg",
+            "nHdUrl": "https://example.com/thumb_nhd.jpg",
+        },
+        "duration": 1,
+        "shortDescription": "",
+        "latestCommentSummary": "",
+        "isChannelVideo": False,
+        "isPaymentRequired": False,
+        "playbackPosition": None,
+        "owner": _owner_payload(),
+        "requireSensitiveMasking": False,
+        "videoLive": None,
+        "isMuted": False,
+    }
+
+
+def _mylist_item_payload() -> dict[str, Any]:
+    """Return a minimal mylist item payload."""
+    return {
+        "itemId": 1,
+        "watchId": "sm9",
+        "description": "memo",
+        "decoratedDescriptionHtml": "memo",
+        "addedAt": "2026-01-01T00:00:00+09:00",
+        "status": "public",
+        "video": _video_payload(),
+    }
+
+
+def _mylist_payload() -> dict[str, Any]:
+    """Return a minimal full mylist payload."""
+    return {
+        "id": 1,
+        "name": "sample",
+        "description": "desc",
+        "decoratedDescriptionHtml": "desc",
+        "defaultSortKey": "addedAt",
+        "defaultSortOrder": "desc",
+        "items": [_mylist_item_payload()],
+        "totalItemCount": 1,
+        "hasNext": False,
+        "isPublic": False,
+        "owner": _owner_payload(),
+        "hasInvisibleItems": False,
+        "followerCount": 0,
+        "isFollowing": False,
+    }
 
 
 def test_get_following_activities_builds_cursor_query() -> None:
@@ -53,4 +162,122 @@ def test_get_following_activities_builds_cursor_query() -> None:
     assert result.activities == []
     assert niconico.urls == [
         "https://api.feed.nicovideo.jp/v1/activities/followings/publish?context=my_timeline&cursor=cursor-1",
+    ]
+
+
+def test_get_own_mylist_builds_sort_query() -> None:
+    """Own mylist detail requests include optional sorting parameters."""
+    payload = {"meta": {"status": 200}, "data": {"mylist": _mylist_payload()}}
+    niconico = DummyNicoNico(payload)
+    client = UserClient(niconico)  # type: ignore[arg-type]
+
+    result = client.get_own_mylist("1", page_size=5, sort_key="addedAt", sort_order="asc")
+
+    assert result is not None
+    assert result.id_ == 1
+    assert niconico.urls == [
+        "https://nvapi.nicovideo.jp/v1/users/me/mylists/1?pageSize=5&page=1&sortKey=addedAt&sortOrder=asc",
+    ]
+
+
+def test_get_own_mylist_items_returns_item_focused_data() -> None:
+    """Own mylist item endpoint returns the direct data object."""
+    data = _mylist_payload()
+    data.pop("hasInvisibleItems")
+    data.pop("followerCount")
+    data.pop("isFollowing")
+    payload = {"meta": {"status": 200}, "data": data}
+    niconico = DummyNicoNico(payload)
+    client = UserClient(niconico)  # type: ignore[arg-type]
+
+    result = client.get_own_mylist_items("1", page_size=5, sort_key="viewCount", sort_order="desc")
+
+    assert result is not None
+    assert result.items[0].watch_id == "sm9"
+    assert niconico.urls == [
+        "https://nvapi.nicovideo.jp/v1/users/me/mylists/1/items?pageSize=5&page=1&sortKey=viewCount&sortOrder=desc",
+    ]
+
+
+def test_add_mylist_item_accepts_description_and_existing_item_success() -> None:
+    """Adding an already registered video returns 200 and still counts as success."""
+    niconico = DummyNicoNico({"meta": {"status": 200}})
+    client = UserClient(niconico)  # type: ignore[arg-type]
+
+    result = client.add_mylist_item("1", "sm9", description="memo note")
+
+    assert result is True
+    assert niconico.calls == [
+        (
+            "POST",
+            "https://nvapi.nicovideo.jp/v1/users/me/mylists/1/items?itemId=sm9&description=memo+note",
+            {"data": None, "json": None},
+        ),
+    ]
+
+
+def test_update_mylist_sends_only_supplied_metadata() -> None:
+    """Own mylist metadata updates omit unspecified fields."""
+    payload = {"meta": {"status": 200}, "data": {"mylist": _mylist_payload()}}
+    niconico = DummyNicoNico(payload)
+    client = UserClient(niconico)  # type: ignore[arg-type]
+
+    result = client.update_mylist("1", name="renamed", is_public=False, default_sort_order="asc")
+
+    assert result is not None
+    assert niconico.calls == [
+        (
+            "PUT",
+            "https://nvapi.nicovideo.jp/v1/users/me/mylists/1",
+            {"data": {"name": "renamed", "isPublic": "false", "defaultSortOrder": "asc"}, "json": None},
+        ),
+    ]
+
+
+def test_reorder_mylists_returns_ordered_ids() -> None:
+    """Own mylist reordering sends a comma-separated full order."""
+    payload = {"meta": {"status": 200}, "data": {"mylistIds": [3, 2, 1]}}
+    niconico = DummyNicoNico(payload)
+    client = UserClient(niconico)  # type: ignore[arg-type]
+
+    result = client.reorder_mylists([3, "2", 1])
+
+    assert result is not None
+    assert result.mylist_ids == [3, 2, 1]
+    assert niconico.calls == [
+        ("PUT", "https://nvapi.nicovideo.jp/v1/users/me/mylists/order", {"data": {"order": "3,2,1"}, "json": None}),
+    ]
+
+
+def test_delete_mylist_uses_delete_endpoint() -> None:
+    """Own mylist deletion calls the documented endpoint."""
+    niconico = DummyNicoNico({"meta": {"status": 200}})
+    client = UserClient(niconico)  # type: ignore[arg-type]
+
+    result = client.delete_mylist("1")
+
+    assert result is True
+    assert niconico.calls == [("DELETE", "https://nvapi.nicovideo.jp/v1/users/me/mylists/1", {})]
+
+
+def test_copy_mylist_items_returns_processed_and_duplicated_ids() -> None:
+    """Copying mylist items parses the processed item summary."""
+    payload = {
+        "meta": {"status": 200},
+        "data": {"duplicatedIds": ["sm1"], "processedIds": ["sm9"]},
+    }
+    niconico = DummyNicoNico(payload)
+    client = UserClient(niconico)  # type: ignore[arg-type]
+
+    result = client.copy_mylist_items("1", "2", ["sm9", "sm1"])
+
+    assert result is not None
+    assert result.processed_ids == ["sm9"]
+    assert result.duplicated_ids == ["sm1"]
+    assert niconico.calls == [
+        (
+            "POST",
+            "https://nvapi.nicovideo.jp/v1/users/me/copy-mylist-items?from=1&to=2&itemIds=sm9,sm1",
+            {"data": None, "json": None},
+        ),
     ]

--- a/tests/test_user_client.py
+++ b/tests/test_user_client.py
@@ -28,9 +28,10 @@ class DummyNicoNico:
     logined = True
     premium = False
 
-    def __init__(self, payload: dict[str, Any]) -> None:
+    def __init__(self, payload: dict[str, Any], *, status_code: int = requests.codes.ok) -> None:
         """Initialize captured URLs and response payload."""
         self.payload = payload
+        self.status_code = status_code
         self.urls: list[str] = []
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
 
@@ -39,7 +40,7 @@ class DummyNicoNico:
         _ = headers
         self.urls.append(url)
         self.calls.append(("GET", url, {}))
-        return DummyResponse(self.payload)
+        return DummyResponse(self.payload, self.status_code)
 
     def post(
         self,

--- a/tests/test_user_client.py
+++ b/tests/test_user_client.py
@@ -190,12 +190,12 @@ def test_get_own_mylist_items_returns_item_focused_data() -> None:
     niconico = DummyNicoNico(payload)
     client = UserClient(niconico)  # type: ignore[arg-type]
 
-    result = client.get_own_mylist_items("1", page_size=5, sort_key="viewCount", sort_order="desc")
+    result = client.get_own_mylist_items("1", sort_key="viewCount", sort_order="desc")
 
     assert result is not None
     assert result.items[0].watch_id == "sm9"
     assert niconico.urls == [
-        "https://nvapi.nicovideo.jp/v1/users/me/mylists/1/items?pageSize=5&page=1&sortKey=viewCount&sortOrder=desc",
+        "https://nvapi.nicovideo.jp/v1/users/me/mylists/1/items?sortKey=viewCount&sortOrder=desc",
     ]
 
 


### PR DESCRIPTION
## 変更点
- #52 のMyList変更系APIを追加
  - メタデータ更新
  - マイリスト順序更新
  - マイリスト削除
  - items専用取得
  - 別マイリストへの動画コピー
- 既存の動画追加APIでdescription指定と重複時200成功を扱うように変更
- PUTリクエスト用のHTTP helperを追加
- MyList APIのunit testを追加
- 専用テストアカウントの認証情報を使い、一時マイリストを作成・削除するlive testをCIで実行
  - CIではメールログインを優先し、失敗時にsessionへfallback
- `/items`専用endpointが現在405を返す場合は、own mylist detail endpointからitemsデータを返すfallbackを追加

Closes #52

## 確認
- `actionlint .github/workflows/ci.yml`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest`
- `uv build`
- メールログイン優先の認証で `uv run pytest tests/integration/test_user.py::test_authenticated_mylist_write_apis -q`
