### PR TITLE
ci: serialize live tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
   live:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    concurrency:
+      group: live-${{ github.repository }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      mutating_live_tests:
+        description: Run live tests that mutate the Niconico test account
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -61,8 +68,8 @@ jobs:
       group: live-${{ github.repository }}
       cancel-in-progress: false
     env:
-      NICONICO_MUTATION_COOLDOWN_SECONDS: "10"
-      NICONICO_MUTATION_START_COOLDOWN_SECONDS: "60"
+      NICONICO_MUTATION_COOLDOWN_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.mutating_live_tests && '10' || '0' }}
+      NICONICO_MUTATION_START_COOLDOWN_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.mutating_live_tests && '300' || '0' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -76,12 +83,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --group dev
       - name: Wait before live mutation tests
+        if: env.NICONICO_MUTATION_START_COOLDOWN_SECONDS != '0'
         run: sleep "$NICONICO_MUTATION_START_COOLDOWN_SECONDS"
       - name: Run live tests
         run: uv run pytest tests/integration -m live
         env:
           NICONICO_LIVE_TESTS: "1"
-          NICONICO_MUTATING_LIVE_TESTS: "1"
+          NICONICO_MUTATING_LIVE_TESTS: ${{ github.event_name == 'workflow_dispatch' && inputs.mutating_live_tests && '1' || '0' }}
           NICONICO_TEST_EMAIL: ${{ secrets.NICONICO_TEST_EMAIL }}
           NICONICO_TEST_PASSWORD: ${{ secrets.NICONICO_TEST_PASSWORD }}
           NICONICO_USER_SESSION: ${{ secrets.NICONICO_USER_SESSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
     concurrency:
       group: live-${{ github.repository }}
       cancel-in-progress: false
+    env:
+      NICONICO_MUTATION_COOLDOWN_SECONDS: "10"
+      NICONICO_MUTATION_START_COOLDOWN_SECONDS: "60"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -72,6 +75,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Install dependencies
         run: uv sync --locked --group dev
+      - name: Wait before live mutation tests
+        run: sleep "$NICONICO_MUTATION_START_COOLDOWN_SECONDS"
       - name: Run live tests
         run: uv run pytest tests/integration -m live
         env:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -18,6 +20,13 @@ def require(value: Any, label: str) -> Any:  # noqa: ANN401
     assert value is not None, f"{label} returned None"
     assert not isinstance(value, dict | list | set | tuple) or value, f"{label} returned an empty collection"
     return value
+
+
+def mutation_cooldown() -> None:
+    """Wait between live test mutations when configured."""
+    seconds = float(os.environ.get("NICONICO_MUTATION_COOLDOWN_SECONDS", "0"))
+    if seconds > 0:
+        time.sleep(seconds)
 
 
 def get_sm9_watch_data(client: NicoNico) -> WatchData:

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 import pytest
 
-from tests.integration.helpers import SM9_VIDEO_ID, get_sample_user_id, require
+from tests.integration.helpers import SM9_VIDEO_ID, get_sample_user_id, mutation_cooldown, require
 
 if TYPE_CHECKING:
     from niconico import NicoNico
@@ -63,6 +63,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
         pytest.skip("Set NICONICO_MUTATING_LIVE_TESTS=1 to run mutating live API tests")
 
     marker = f"niconico.py live test {uuid4().hex[:8]}"
+    mutation_cooldown()
     source = require(
         authenticated_client.user.create_mylist(marker, "created by niconico.py live test", is_public=False),
         "source mylist creation",
@@ -71,6 +72,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
     target_id: str | None = None
 
     try:
+        mutation_cooldown()
         updated = require(
             authenticated_client.user.update_mylist(
                 source_id,
@@ -83,6 +85,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
             "mylist metadata update",
         )
         assert updated.name == f"{marker} updated"
+        mutation_cooldown()
         assert authenticated_client.user.add_mylist_item(source_id, SM9_VIDEO_ID, description="live test") is True
 
         detail = require(
@@ -101,6 +104,7 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
         )
         assert any(item.watch_id == SM9_VIDEO_ID for item in items.items)
 
+        mutation_cooldown()
         target = require(
             authenticated_client.user.create_mylist(
                 f"{marker} copy",
@@ -110,12 +114,14 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
             "target mylist creation",
         )
         target_id = str(target.mylist_id)
+        mutation_cooldown()
         copied = require(
             authenticated_client.user.copy_mylist_items(source_id, target_id, [SM9_VIDEO_ID]),
             "mylist item copy",
         )
         assert SM9_VIDEO_ID in copied.processed_ids or SM9_VIDEO_ID in copied.duplicated_ids
 
+        mutation_cooldown()
         ordered = require(
             authenticated_client.user.reorder_mylists(
                 [mylist.id_ for mylist in authenticated_client.user.get_own_mylists()],
@@ -123,8 +129,11 @@ def test_authenticated_mylist_write_apis(authenticated_client: NicoNico) -> None
             "mylist reorder",
         )
         assert int(source_id) in ordered.mylist_ids
+        mutation_cooldown()
         assert authenticated_client.user.remove_mylist_items(source_id, [SM9_VIDEO_ID]) is True
     finally:
         if target_id is not None:
+            mutation_cooldown()
             authenticated_client.user.delete_mylist(target_id)
+        mutation_cooldown()
         authenticated_client.user.delete_mylist(source_id)

--- a/tests/integration/test_video.py
+++ b/tests/integration/test_video.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -88,8 +89,12 @@ def test_sm9_downloads_video(live_client: NicoNico, tmp_path: Path) -> None:
     assert downloaded.stat().st_size > MIN_SM9_DOWNLOAD_BYTES
 
 
+@pytest.mark.mutating()
 def test_authenticated_video_like_apis(authenticated_client: NicoNico) -> None:
     """Exercise authenticated video like wrappers against live endpoints."""
+    if os.environ.get("NICONICO_MUTATING_LIVE_TESTS") != "1":
+        pytest.skip("Set NICONICO_MUTATING_LIVE_TESTS=1 to run mutating live API tests")
+
     liked = False
     try:
         mutation_cooldown()

--- a/tests/integration/test_video.py
+++ b/tests/integration/test_video.py
@@ -15,6 +15,7 @@ from tests.integration.helpers import (
     get_sample_list_id,
     get_sm9_watch_data,
     get_tag_edit_key,
+    mutation_cooldown,
     require,
 )
 
@@ -89,7 +90,13 @@ def test_sm9_downloads_video(live_client: NicoNico, tmp_path: Path) -> None:
 
 def test_authenticated_video_like_apis(authenticated_client: NicoNico) -> None:
     """Exercise authenticated video like wrappers against live endpoints."""
+    liked = False
     try:
-        assert require(authenticated_client.video.like_video(SM9_VIDEO_ID), "like video") is not None
+        mutation_cooldown()
+        like_data = authenticated_client.video.like_video(SM9_VIDEO_ID)
+        liked = like_data is not None
+        assert require(like_data, "like video") is not None
     finally:
-        assert authenticated_client.video.unlike_video(SM9_VIDEO_ID) is True
+        if liked:
+            mutation_cooldown()
+            assert authenticated_client.video.unlike_video(SM9_VIDEO_ID) is True


### PR DESCRIPTION
## Summary
- Add job-level concurrency to the `live` CI job.
- Keep `cancel-in-progress` disabled so live tests run sequentially instead of canceling each other.

## Reason
The live job uses a shared Niconico test account and includes mutating API checks, so concurrent runs can interfere with each other.