### PR TITLE
release: v2.2.1

### DIFF
--- a/niconico/__init__.py
+++ b/niconico/__init__.py
@@ -3,4 +3,4 @@
 from niconico.niconico import NicoNico
 
 __all__ = ("NicoNico",)
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "niconico.py"
-version = "2.2.0"
+version = "2.2.1"
 description = "API wrapper for NicoNico services"
 authors = [{ name = "Negima1072", email = "ngm1072@gmail.com" }]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -357,7 +357,7 @@ wheels = [
 
 [[package]]
 name = "niconico-py"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "idna" },


### PR DESCRIPTION
## Summary
- Bump package version to `2.2.1`.
- Update `uv.lock` to match the release version.

## Notes
- This PR only contains release version metadata.